### PR TITLE
Property display, imshow2() wrapper, memory

### DIFF
--- a/more diagnostics/imshow2.cpp
+++ b/more diagnostics/imshow2.cpp
@@ -1,0 +1,51 @@
+/*
+ * imshow2.cpp
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: jonathan
+ */
+
+#include "imshow2.hpp"
+//#include <chrono>
+//using std::chrono::system_clock;
+/*
+ * imshow2() is an imshow() wrapper that also displays processing frame rate of the calling program (assumedly a while-loop).
+ * Requires that std::time_t loop_top = time(0); is set at the start of the calling while-loop that imshow2() is in. #include <chrono>
+ * Requires caller to have declared an int array of size 22 with all values 0, and pass its pointer into imshow2().
+ */
+
+/* About time_array[] input variable
+ * Remember that all time_array[] values should have been initialized to 0 before passing it in to imshow2().
+ * time_array[0 through 19] = the time_t values (casted as int) holding the time used to process one frame in the calling program.
+ * time_array[20] = cumulative sum of time_t values.
+ * time_array[21] = counter/indexer used to update the rolling mean used to calculate the processing frame rate.
+ * processing fps = 1 / (time_array[20] / 20), requires scaling according to desired time unit.
+ */
+
+void imshow2(const string& winname, cv::Mat mat, double time_array[], system_clock::time_point loop_start){
+
+
+	int index = time_array[21]; // Used to make code more readable.
+	time_array[20] -= time_array[ index ]; // Remove (subtract) oldest time value from cumulative sum.
+	double frame_process_time = chrono::duration_cast<chrono::milliseconds> (system_clock::now() - loop_start).count(); // time(ms) to compute current frame
+	time_array[ index ] = frame_process_time; // Add current frame's process time to the array of time values.
+	time_array[20] += time_array[ index ]; // Add the current frame's process time to cumulative sum.
+	double avg_ms_per_frame = time_array[20] / 20; // Divide cumulative time(ms) sum by 20 to obtain avg_time(ms) that was required to compute the last 20 frames so far.
+	double avg_s_per_frame = avg_ms_per_frame / 1000; // time_array values are stored as milliseconds, see where double frame_process_time is set above
+	double rolling_avg_fps = 1 / avg_s_per_frame;
+
+	//Display original frame and then also output the processing fps.
+	cv::putText(mat, cv::format("Processing FPS:%.2f", rolling_avg_fps ), cv::Point(10, 170), cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(0,0,255));
+
+	if( time_array[21] > 18)// time-array[21], the counter, should loop between 0-19
+	{
+		time_array[21] = 0;
+	}
+	else
+	{
+		time_array[21]++;
+	}
+
+	imshow(winname, mat);
+}
+

--- a/more diagnostics/imshow2.hpp
+++ b/more diagnostics/imshow2.hpp
@@ -1,0 +1,24 @@
+/*
+ * imshow2.hpp
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: jonathan
+ */
+
+#ifndef IMSHOW2_HPP_
+#define IMSHOW2_HPP_
+
+#include <iostream>
+#include <chrono>
+using namespace std;
+using std::chrono::system_clock;
+//#include "opencv2/imgcodecs.hpp"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/videoio.hpp"
+#include <opencv2/highgui.hpp>
+#include <opencv2/video.hpp>
+#include <opencv2/core.hpp>
+void imshow2(const string &winname, cv::Mat mat, double time_array[], system_clock::time_point loop_start);
+
+#endif /* IMSHOW2_HPP_ */
+

--- a/more diagnostics/memory_used_by_current_process.cpp
+++ b/more diagnostics/memory_used_by_current_process.cpp
@@ -1,0 +1,76 @@
+/*
+ * memory_used_by_current_process.cpp
+ *
+ *  Created on: Oct 26, 2016
+ *      Author: jonathan
+ */
+/*
+ * Only for Linux.
+ * Memory (and other) information for processes is constantly
+ * updated inside the root/proc file. To get memory of a current process,
+ * we can access /proc/self/stat. The stat file contains the status
+ * of a processes including it's various attributes.
+ * See Linux man page for proc, look for /proc/[pid]/status
+ * (distinct from /proc/[pid]/stat and /proc/[pid]/statm)
+ *
+ * Linux /status file terminology of interest:
+ * VmRSS - resident set size, number of pages the process has in real memory (no swap memory)
+ * VmSize - virtual memory size
+ */
+/*
+ * Contains three functions:
+ * 1. int virtualMemoryUsedByCurrentProcess()
+ * 2. int physicalMemoryUsedByCurrentProcess()
+ * 3. int parseLine(char* line) - helper function
+ * Uses ints since file is read directly and values are listed as kB in the Linux file.
+ */
+
+#include "memory_used_by_current_process.hpp"
+//#include <stdio.h>
+
+int virtualMemoryUsedByCurrentProcess(){ // Linux stores mem values in kB.
+    FILE* linux_status_file = fopen("/proc/self/status", "r");
+    int memory_int_value = -1;
+    char file_data_chunk[128];
+
+    // Grab 127 chars at a time while parsing each char set for the desired property
+    // in this case "VmSize." Go through the entire file.
+    while (fgets(file_data_chunk, 128, linux_status_file) != NULL){ //fgets will stop in this linux file when a newline is found
+        if (strncmp(file_data_chunk, "VmSize:", 7) == 0){ // if VmSize is found
+            memory_int_value = parseDataLine(file_data_chunk); // parse the entire line of data
+            break;
+        }
+    }
+    fclose(linux_status_file);
+    return memory_int_value;
+}
+
+int physicalMemoryUsedByCurrentProcess(){ // Linux stores mem values in kB.
+    FILE* linux_status_file = fopen("/proc/self/status", "r");
+    int memory_int_value = -1;
+    char file_data_chunk[128];
+
+    // Grab 127 chars at a time while parsing each char set for the desired property
+    // in this case "VmSize." Go through the entire file.
+    while (fgets(file_data_chunk, 128, linux_status_file) != NULL){ //fgets will stop in this linux file when a newline is found
+        if (strncmp(file_data_chunk, "VmRSS:", 6) == 0){ // if VmSize is found
+            memory_int_value = parseDataLine(file_data_chunk); // parse the entire line of data
+            break;
+        }
+    }
+    fclose(linux_status_file);
+    return memory_int_value;
+}
+
+// Helper function. Used to obtain values from the two above functions.
+int parseDataLine(char* file_data_chunk){
+    // Parse the data chunk for the property's int value.
+	// Linux stores int values in the status page in "[int value] kB" as of 2016.
+    int data = strlen(file_data_chunk);
+    const char* pData = file_data_chunk; // Setup access to the char array input sent in.
+    while (*pData <'0' || *pData > '9') pData++; // Increment across the data line until an integer is found.
+    file_data_chunk[data-3] = '\0'; // The last 3 chars in a line are expected to be " kB" preceded by the int value we want.
+    data = atoi(pData);
+    return data;
+}
+

--- a/more diagnostics/memory_used_by_current_process.hpp
+++ b/more diagnostics/memory_used_by_current_process.hpp
@@ -1,0 +1,21 @@
+/*
+ * memory_used_by_current_process.hpp
+ *
+ *  Created on: Oct 26, 2016
+ *      Author: jonathan
+ */
+#ifndef MEMORY_USED_BY_CURRENT_PROCESS_HPP_
+#define MEMORY_USED_BY_CURRENT_PROCESS_HPP_
+
+#include "stdlib.h"
+#include "stdio.h"
+#include "string.h"
+
+int parseDataLine(char* file_data_chunk); // Helper function for the two memory functions
+
+int virtualMemoryUsedByCurrentProcess(); // in KB
+
+int physicalMemoryUsedByCurrentProcess(); // in KB
+
+#endif /* MEMORY_USED_BY_CURRENT_PROCESS_HPP_ */
+

--- a/more diagnostics/show_video_properties.cpp
+++ b/more diagnostics/show_video_properties.cpp
@@ -1,0 +1,40 @@
+/*
+ * show_video_properties.cpp
+ *
+ *  Created on: Dec 1, 2016
+ *      Author: jonathan
+ */
+
+#include "show_video_properties.hpp"
+
+void show_video_properties(VideoCapture& capture, Mat& frame) {
+        stringstream ss_frames;
+        stringstream ss_fps;
+        stringstream ss_msec;
+        stringstream ss_avi_ratio;
+        rectangle(frame, cv::Point(5, 142), cv::Point(250,240),
+                  cv::Scalar(255,255,255), -1);
+        // Show current frame in the video.
+        ss_frames << "Frame: ";
+        ss_frames << capture.get(CAP_PROP_POS_FRAMES);
+        string frameNumberString = ss_frames.str();
+        putText(frame, frameNumberString.c_str(), cv::Point(5, 155),
+                FONT_HERSHEY_SIMPLEX, 0.5 , cv::Scalar(0,0,0));
+        //Show video's original fps.
+        ss_fps << "Original fps: ";
+        ss_fps << capture.get(CAP_PROP_FPS);
+        string fpsString = ss_fps.str();
+        putText(frame, fpsString.c_str(), cv::Point(5, 185),
+                FONT_HERSHEY_SIMPLEX, 0.5 , cv::Scalar(0,0,0));
+        // Show current time in the video.
+        double video_time_position = capture.get(CAP_PROP_POS_MSEC);
+        video_time_position /= 1000;
+        cv::putText(frame, cv::format("Video time=%.2fs", video_time_position ), cv::Point(5, 200),
+        		cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(0,0,0));
+        // Show % position into the video (from 0 - 100%).
+        double video_percent_position = capture.get(CAP_PROP_POS_FRAMES) / capture.get(CV_CAP_PROP_FRAME_COUNT) * 100;
+        cv::putText(frame, cv::format("Video progress=%.2f%%", video_percent_position ), cv::Point(5, 215),
+        		cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(0,0,0));
+
+}
+

--- a/more diagnostics/show_video_properties.hpp
+++ b/more diagnostics/show_video_properties.hpp
@@ -1,0 +1,23 @@
+/*
+ * show_video_properties.hpp
+ *
+ *  Created on: Dec 1, 2016
+ *      Author: jonathan
+ */
+
+#ifndef SHOW_VIDEO_PROPERTIES_HPP_
+#define SHOW_VIDEO_PROPERTIES_HPP_
+
+#include "opencv2/imgproc.hpp"
+#include "opencv2/videoio.hpp"
+#include <opencv2/highgui.hpp>
+#include <opencv2/video.hpp>
+#include <opencv2/core.hpp>
+#include <sstream>
+using namespace std;
+using namespace cv;
+
+void show_video_properties(VideoCapture& capture, Mat& frame);
+
+#endif /* SHOW_VIDEO_PROPERTIES_HPP_ */
+


### PR DESCRIPTION
Three pairs of .hpp/.cpp files.
Property display: Current frame, original fps, time into vid, % into vid
Imshow2(): Wrapper for imshow() that also displays processing fps.
Memory: Spits out memory from linux (virtual and physical).